### PR TITLE
Use a list for readthedocs extra_requirements.

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -25,4 +25,5 @@ python:
   install:
     - method: pip
       path: .
-      extra_requirements: docs
+      extra_requirements:
+        - docs


### PR DESCRIPTION
There is a bug in the recent `.readthedocs.yaml` configuration file. A [build showed the error](https://app.readthedocs.org/projects/statick/builds/29845585/):

```
Config file validation error

Config validation error in python.install.0.extra_requirements. Expected a list, got type str (docs).
```

The proper syntax is shown in [this example](https://docs.readthedocs.com/platform/stable/config-file/v2.html#python), which I have not copied. 